### PR TITLE
Produce filenames with the same string length

### DIFF
--- a/RTAscience/simBkg.py
+++ b/RTAscience/simBkg.py
@@ -94,7 +94,7 @@ def simulateTrial(trial_args):
     tobs=trial_args[5]
     # initialise ---!
     count = cfg.get('start_count') + i + 1
-    name = f'bkg{count:06d}'
+    name = f'bkg{count:08d}'
     # setup ---!
     sim = RTACtoolsSimulation()
     sim.seed = count


### PR DESCRIPTION
The "id" section of filenames with id < 10e6 is formed with 6 digits, such as:
`bkg000001_t_simtype_bkg_onset_0_normalized_True.csv`

When more of 10e6 files are produced, the number of digits is increased by one:
`bkg9999996_t_simtype_bkg_onset_0_normalized_True.csv`

Let's make a default of 8 digits. 